### PR TITLE
fix: report path supports only one path and leverage glob

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: ./
         with:
           token: fake-valid-token
-          report_paths: zfixtures/junit_example.xml
+          report_path: zfixtures/*.xml
           mergify_api_url: http://localhost:1080
 
       - name: Get job ID
@@ -83,7 +83,7 @@ jobs:
         uses: ./
         with:
           token: fake-valid-token
-          report_paths: zfixtures/junit_example.xml
+          report_path: zfixtures/junit_example.xml
           mergify_api_url: http://localhost:1085
 
       - name: Dump mockserver logs

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,9 @@ inputs:
   token:
     required: true
     description: Mergify CI token
-  report_paths:
+  report_path:
     required: true
-    description: Paths of the files to upload
+    description: Path of the files to upload
   mergify_api_url:
     required: false
     description: URL of the Mergify API
@@ -33,7 +33,7 @@ runs:
       env:
         MERGIFY_API_URL: ${{ inputs.mergify_api_url }}
         MERGIFY_TOKEN: ${{ inputs.token }}
-        FILES: ${{ inputs.report_paths }}
+        FILES: ${{ inputs.report_path }}
       run: |
         set -x -e
-        mergify ci junit-upload "${FILES}"
+        mergify ci junit-upload ${FILES}


### PR DESCRIPTION
Removes the s which is misleading and make sure it works with glob
patterns.