### PR TITLE
ci: fix upload path and error scenario

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,12 +86,6 @@ jobs:
           report_paths: zfixtures/junit_example.xml
           mergify_api_url: http://localhost:1085
 
-      - name: Check error was reported
-        if: ${{ steps.error500.outcome == 'success' }}
-        run: |
-          echo "Error succeeded, that's not correct."
-          exit 1
-
       - name: Dump mockserver logs
         if: always()
         run: |
@@ -102,7 +96,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - name: Check GIGID
+      - name: Check annotation
         uses: actions/github-script@v7
         with:
           script: |
@@ -112,7 +106,7 @@ jobs:
               check_run_id: ${{ needs.test.outputs.job_id }},
             });
             for (const annotation of annotations.data) {
-              if (annotation.message === "CI_ISSUE_GIGID=1234azertyuiop") {
+              if (annotation.message.startsWith("MERGIFY_TEST_ROOT_SPAN_ID=")) {
                 core.info(`Annotations found: ${annotation.message}`)
                 return
               }

--- a/zfixtures/fake-ci-issue-api.json
+++ b/zfixtures/fake-ci-issue-api.json
@@ -2,23 +2,13 @@
     {
         "httpRequest": {
             "method": "POST",
-            "path": "/v1/repos/Mergifyio/gha-mergify-ci/ci_issues_upload",
+            "path": "/v1/repos/Mergifyio/gha-mergify-ci/ci/traces",
             "headers": {
                 "Authorization": "Bearer fake-valid-token"
             },
-            "body": {
-                "type": "REGEX",
-                "regex": ".*Content-Disposition: form-data; name=\\\"head_sha\\\"\\r\\n\\r\\n.*\\r\\n.*\\r\\nContent-Disposition: form-data; name=\"name\"\r\n\r\nContinuous Integration\r\n.*Content-Disposition: form-data; name=\"provider\"\r\n\r\ngithub_action\r\n.*Content-Disposition: form-data; name=\"files\"; filename=\"junit_example.xml\"\r\nContent-Type: application/xml\r\n\r\n.*"
-            }
         },
         "httpResponse": {
             "statusCode": 200,
-            "body": "{\"gigid\": \"1234azertyuiop\"}",
-            "headers": {
-                "Content-Type": [
-                    "application/json"
-                ]
-            }
         }
     }
 ]


### PR DESCRIPTION
The current code uploads in a different endpoint and the test is getting
a 404.

The Mergify CLI works differently and does not fail on upload issues to
avoid blocking user CI; adapt the scenario.